### PR TITLE
[Flutter最終課題]Tagページ・タグ一覧を取得してデータ表示

### DIFF
--- a/lib/models/tag.dart
+++ b/lib/models/tag.dart
@@ -1,0 +1,24 @@
+class Tag {
+  int? followersCount;
+  String? iconUrl;
+  String? id;
+  int? itemsCount;
+
+  Tag({this.followersCount, this.iconUrl, this.id, this.itemsCount});
+
+  Tag.fromJson(Map<String, dynamic> json) {
+    followersCount = json['followers_count'];
+    iconUrl = json['icon_url'];
+    id = json['id'];
+    itemsCount = json['items_count'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = new Map<String, dynamic>();
+    data['followers_count'] = followersCount;
+    data['icon_url'] = iconUrl;
+    data['id'] = id;
+    data['items_count'] = itemsCount;
+    return data;
+  }
+}

--- a/lib/pages/bottom_navigation.dart
+++ b/lib/pages/bottom_navigation.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:qiita_client_yukiy/pages/tag_page.dart';
 
 import '../pages/settings_page.dart';
 import 'feed_page.dart';
@@ -15,10 +16,7 @@ class _BottomNavigationState extends State<BottomNavigation> {
 
   final _pages = <Widget>[
     const FeedPage(),
-    Container(
-      alignment: Alignment.center,
-      child: const Text('タグ'),
-    ),
+    TagPage(),
     Container(
       alignment: Alignment.center,
       color: Colors.lightBlue,

--- a/lib/pages/tag_page.dart
+++ b/lib/pages/tag_page.dart
@@ -5,7 +5,7 @@ import 'package:qiita_client_yukiy/ui_components/tag_grid_view.dart';
 import 'package:qiita_client_yukiy/ui_components/upper_bar.dart';
 
 class TagPage extends StatefulWidget {
-  TagPage({
+  const TagPage({
     Key? key,
   }) : super(key: key);
 

--- a/lib/pages/tag_page.dart
+++ b/lib/pages/tag_page.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:qiita_client_yukiy/models/tag.dart';
+import 'package:qiita_client_yukiy/services/qiita_client.dart';
+import 'package:qiita_client_yukiy/ui_components/tag_grid_view.dart';
+import 'package:qiita_client_yukiy/ui_components/upper_bar.dart';
+
+class TagPage extends StatefulWidget {
+  TagPage({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  State<TagPage> createState() => _TagPageState();
+}
+
+class _TagPageState extends State<TagPage> {
+  List<Tag> listTags = [];
+  late bool _isLoading = true;
+  int pageNumber = 1;
+  late Future<List<Tag>> futureTags;
+
+  @override
+  void initState() {
+    _fetchTagData();
+    super.initState();
+  }
+
+  Future<void> _fetchTagData() async {
+    _isLoading = false;
+    futureTags = QiitaClient.fetchTags(pageNumber);
+    listTags.addAll(await futureTags);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: const UpperBar(
+        showSearchBar: false,
+        appBarText: 'Tags',
+        textField: TextField(),
+      ),
+      body: FutureBuilder<List<Tag>>(
+        future: QiitaClient.fetchTags(pageNumber),
+        builder: (context, snapshot) {
+          return TagGridView(
+            tagList: listTags,
+            itemCount: _isLoading ? listTags.length + 1 : listTags.length,
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/pages/tag_page.dart
+++ b/lib/pages/tag_page.dart
@@ -26,9 +26,10 @@ class _TagPageState extends State<TagPage> {
   }
 
   Future<void> _fetchTagData() async {
+    List<Tag> newFetchTag;
     _isLoading = false;
-    futureTags = QiitaClient.fetchTags(pageNumber);
-    listTags.addAll(await futureTags);
+    newFetchTag = await QiitaClient.fetchTags(pageNumber);
+    listTags.addAll(newFetchTag);
   }
 
   @override

--- a/lib/services/qiita_client.dart
+++ b/lib/services/qiita_client.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 import '../models/article.dart';
+import '../models/tag.dart';
 
 class QiitaClient {
   static Future<List<Article>> fetchArticle(
@@ -21,6 +22,23 @@ class QiitaClient {
     } else {
       throw Exception(
           'Request failed with status: ${response.statusCode}${response.body}');
+    }
+  }
+
+  static Future<List<Tag>> fetchTags(int pageNumber) async {
+    String url =
+        'https://qiita.com/api/v2/tags?page=$pageNumber&per_page=20&sort=count';
+
+    final response = await http.get(Uri.parse(url));
+    if (response.statusCode == 200) {
+      final List<dynamic> jsonArray = json.decode(response.body);
+      final tagList = jsonArray.map((json) => Tag.fromJson(json)).toList();
+      print(tagList[0].iconUrl);
+      return tagList;
+    } else {
+      throw Exception(
+        'Request failed with status: ${response.statusCode}${response.body}',
+      );
     }
   }
 }

--- a/lib/services/qiita_client.dart
+++ b/lib/services/qiita_client.dart
@@ -33,7 +33,6 @@ class QiitaClient {
     if (response.statusCode == 200) {
       final List<dynamic> jsonArray = json.decode(response.body);
       final tagList = jsonArray.map((json) => Tag.fromJson(json)).toList();
-      print(tagList[0].iconUrl);
       return tagList;
     } else {
       throw Exception(

--- a/lib/ui_components/tag_grid_view.dart
+++ b/lib/ui_components/tag_grid_view.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:qiita_client_yukiy/ui_components/tag_grid_view_cell.dart';
+
+import '../models/tag.dart';
+
+class TagGridView extends StatelessWidget {
+  const TagGridView({
+    Key? key,
+    required this.itemCount,
+    required this.tagList,
+  }) : super(key: key);
+
+  final int itemCount;
+  final List<Tag> tagList;
+
+  @override
+  Widget build(BuildContext context) {
+    Size deviceSize = MediaQuery.of(context).size;
+    double columnWidth = 170;
+    int columnCount = deviceSize.width ~/ columnWidth;
+    return GridView.builder(
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+        // 横1行あたりに表示するWidgetの数
+        crossAxisCount: columnCount,
+      ),
+      itemCount: itemCount,
+      itemBuilder: (BuildContext context, int index) {
+        final tag = tagList[index];
+        return TagGridViewCell(
+          tag: tag,
+        );
+      },
+    );
+  }
+}

--- a/lib/ui_components/tag_grid_view_cell.dart
+++ b/lib/ui_components/tag_grid_view_cell.dart
@@ -21,7 +21,6 @@ class TagGridViewCell extends StatelessWidget {
         ),
       ),
       child: Column(
-        crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           Flexible(
             child: Center(
@@ -34,38 +33,28 @@ class TagGridViewCell extends StatelessWidget {
             child: Container(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[
-                  Align(
-                    alignment: Alignment.center,
-                    child: Text(
-                      tag.id!,
-                      style: const TextStyle(
-                          fontSize: 14, fontWeight: FontWeight.w500),
-                      maxLines: 1,
-                    ),
+                  Text(
+                    tag.id!,
+                    style: const TextStyle(
+                        fontSize: 14, fontWeight: FontWeight.w500),
+                    maxLines: 1,
                   ),
                   Container(
-                    child: Align(
-                      alignment: Alignment.center,
-                      child: Text(
-                        "記事件数: ${tag.itemsCount}",
-                        style: const TextStyle(
-                          fontSize: 12,
-                          color: Color(0xFF828282),
-                        ),
+                    child: Text(
+                      "記事件数: ${tag.itemsCount}",
+                      style: const TextStyle(
+                        fontSize: 12,
+                        color: Color(0xFF828282),
                       ),
                     ),
                   ),
                   Container(
-                    child: Align(
-                      alignment: Alignment.center,
-                      child: Text(
-                        "フォロワー数: ${tag.followersCount}",
-                        style: const TextStyle(
-                          fontSize: 12,
-                          color: Color(0xFF828282),
-                        ),
+                    child: Text(
+                      "フォロワー数: ${tag.followersCount}",
+                      style: const TextStyle(
+                        fontSize: 12,
+                        color: Color(0xFF828282),
                       ),
                     ),
                   )

--- a/lib/ui_components/tag_grid_view_cell.dart
+++ b/lib/ui_components/tag_grid_view_cell.dart
@@ -30,36 +30,30 @@ class TagGridViewCell extends StatelessWidget {
             ),
           ),
           Flexible(
-            child: Container(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: <Widget>[
-                  Text(
-                    tag.id!,
-                    style: const TextStyle(
-                        fontSize: 14, fontWeight: FontWeight.w500),
-                    maxLines: 1,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                Text(
+                  tag.id!,
+                  style: const TextStyle(
+                      fontSize: 14, fontWeight: FontWeight.w500),
+                  maxLines: 1,
+                ),
+                Text(
+                  "記事件数: ${tag.itemsCount}",
+                  style: const TextStyle(
+                    fontSize: 12,
+                    color: Color(0xFF828282),
                   ),
-                  Container(
-                    child: Text(
-                      "記事件数: ${tag.itemsCount}",
-                      style: const TextStyle(
-                        fontSize: 12,
-                        color: Color(0xFF828282),
-                      ),
-                    ),
+                ),
+                Text(
+                  "フォロワー数: ${tag.followersCount}",
+                  style: const TextStyle(
+                    fontSize: 12,
+                    color: Color(0xFF828282),
                   ),
-                  Container(
-                    child: Text(
-                      "フォロワー数: ${tag.followersCount}",
-                      style: const TextStyle(
-                        fontSize: 12,
-                        color: Color(0xFF828282),
-                      ),
-                    ),
-                  )
-                ],
-              ),
+                )
+              ],
             ),
           )
         ],

--- a/lib/ui_components/tag_grid_view_cell.dart
+++ b/lib/ui_components/tag_grid_view_cell.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+
+import '../models/tag.dart';
+
+class TagGridViewCell extends StatelessWidget {
+  const TagGridViewCell({Key? key, required this.tag}) : super(key: key);
+
+  final Tag tag;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 162,
+      height: 138,
+      padding: const EdgeInsets.all(20),
+      margin: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: const BorderRadius.all(Radius.circular(10)),
+        border: Border.all(
+          color: const Color(0xFFE0E0E0),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Flexible(
+            child: Center(
+              child: Image.network(
+                tag.iconUrl.toString(),
+              ),
+            ),
+          ),
+          Flexible(
+            child: Container(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Align(
+                    alignment: Alignment.center,
+                    child: Text(
+                      tag.id!,
+                      style: const TextStyle(
+                          fontSize: 14, fontWeight: FontWeight.w500),
+                      maxLines: 1,
+                    ),
+                  ),
+                  Container(
+                    child: Align(
+                      alignment: Alignment.center,
+                      child: Text(
+                        "記事件数: ${tag.itemsCount}",
+                        style: const TextStyle(
+                          fontSize: 12,
+                          color: Color(0xFF828282),
+                        ),
+                      ),
+                    ),
+                  ),
+                  Container(
+                    child: Align(
+                      alignment: Alignment.center,
+                      child: Text(
+                        "フォロワー数: ${tag.followersCount}",
+                        style: const TextStyle(
+                          fontSize: 12,
+                          color: Color(0xFF828282),
+                        ),
+                      ),
+                    ),
+                  )
+                ],
+              ),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui_components/tag_grid_view_cell.dart
+++ b/lib/ui_components/tag_grid_view_cell.dart
@@ -10,7 +10,6 @@ class TagGridViewCell extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: 162,
       height: 138,
       padding: const EdgeInsets.all(20),
       margin: const EdgeInsets.all(8),

--- a/lib/ui_components/upper_bar.dart
+++ b/lib/ui_components/upper_bar.dart
@@ -18,7 +18,7 @@ class UpperBar extends StatelessWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     return AppBar(
-      elevation: 0, //影を消す
+      elevation: 0.5, //影を消す
       backgroundColor: Colors.white,
       title: Text(
         appBarText,


### PR DESCRIPTION
## 概要
Tagページ、タグ一覧を取得してデータ表示を実装しました。
## 実装内容
- APIを取得
- tag_grid_view_cell.dartでタグ一つ分のUIを作成
- GridView.builderを用いてGridViewを作成
- 取得したTagデータを画面に一覧表示
## 参考になった記事
- [【Flutter】APIからデータを取得しよう](https://blog.shinonome.io/p/41b90380-4fcf-4922-8b3e-1435b91cf2db/#for-toc-6)
- [GridView class ](https://api.flutter.dev/flutter/widgets/GridView-class.html)
- [【Flutter】Containerに角丸の枠線やボーダーをつける【BoxDecoration】](https://www.egao-inc.co.jp/programming/flutter_borderline_radius/#Container)
- [Flutterで非同期で格子状に画像とテキストを表示する方法](https://teratail.com/questions/247980)
- [GridViewでコンテンツを一覧表示 -ひとりアドベントカレンダー Flutter編 2018 その1-](https://note.com/nbht/n/n77c331665fda)
- [【Flutter】GridViewでインスタグラム風UIを簡単作成【サンプルコード】](https://gakogako.com/flutter_gridview/#%E5%86%99%E7%9C%9F%E3%82%A2%E3%83%97%E3%83%AA%E3%81%AE%E6%A7%98%E3%81%AAUI%E3%82%92%E7%B0%A1%E5%8D%98%E3%81%AB%E4%BD%9C%E3%82%8C%E3%82%8B)
## 反省
定期的にコミットすることを忘れていた。
今後はこれから行うタスクをあらかじめ細分化した上で、一つ一つコミットすることを意識していきたい。

## 実際の画面
### iPhone 14
<img src="https://user-images.githubusercontent.com/102783724/222883778-c57064d2-0f58-47eb-acdc-1f128504c2fd.png" width="300">

### iPad Air 5
<img src="https://user-images.githubusercontent.com/102783724/222883800-faa522ca-70f3-404d-b184-b7f1b2e53a9a.png" width="350">

